### PR TITLE
create_encoder should use Json.Encode.*

### DIFF
--- a/decoder.py
+++ b/decoder.py
@@ -60,20 +60,20 @@ def field_name_and_type(string):
 
     return (splitted[0].strip(), splitted[1].strip())
 
-def make_guess_at_decoder(string):
+def make_guess_at_codec(string):
     return string.lower()
 
-def prefix_decoder(prefix, value):
+def prefix_codec(prefix, value, default_module=JSON_DECODE):
     parts = value.split()
 
     return ' '.join(
-        JSON_DECODE + value
+        default_module + value
             if value in KNOWN_DECODERS
             else prefix + value.capitalize()
             for value in parts
     )
 
-def suffix_decoder(suffix, value):
+def suffix_codec(suffix, value):
     parts = value.split()
 
     return ' '.join(
@@ -94,13 +94,13 @@ def create_decoder(string, has_snakecase=False, prefix=None, suffix=None):
                 for name, value in fields
         ]
 
-    fields = [(name, make_guess_at_decoder(type)) for name, type in fields]
+    fields = [(name, make_guess_at_codec(type)) for name, type in fields]
 
     if prefix is not None:
-        fields = [ (name, prefix_decoder(prefix, value)) for name, value in fields ]
+        fields = [ (name, prefix_codec(prefix, value)) for name, value in fields ]
 
     if suffix is not None:
-        fields = [ (name, suffix_decoder(suffix, value)) for name, value in fields ]
+        fields = [ (name, suffix_codec(suffix, value)) for name, value in fields ]
 
 
     formattedFields ='\n        '.join(
@@ -135,13 +135,13 @@ def create_encoder(string, has_snakecase=False, prefix=None, suffix=None):
                 for name, value in fields
         ]
 
-    fields = [(name, make_guess_at_decoder(type)) for name, type in fields]
+    fields = [(name, make_guess_at_codec(type)) for name, type in fields]
 
     if prefix is not None:
-        fields = [ (name, prefix_decoder(prefix, value)) for name, value in fields ]
+        fields = [ (name, prefix_codec(prefix, value, JSON_ENCODE)) for name, value in fields ]
 
     if suffix is not None:
-        fields = [ (name, suffix_decoder(suffix, value)) for name, value in fields ]
+        fields = [ (name, suffix_codec(suffix, value)) for name, value in fields ]
 
     formatted_fields ='\n        , '.join(
         '("{name}", {type} record.{original_name})'

--- a/generate.py
+++ b/generate.py
@@ -101,26 +101,30 @@ view =
     div [] []
 """
 
+
+def message(*args):
+    print(*args, file=sys.stderr)
+
+
 def main():
     if len(sys.argv) < 2:
-        print('Give me some elm file names and I\'ll give you decoders and encoders')
-        print('Or give me some json files and I\'ll give you a type alias and decoders and encoders')
+        message('Give me some elm file names and I\'ll give you decoders and encoders')
+        message('Or give me some json files and I\'ll give you a type alias and decoders and encoders')
         return
 
 
     for arg in sys.argv[1:]:
         if arg.endswith('.elm'):
-            print('Generating decoders and encoders for {name}'.format(name=arg))
+            message('Generating decoders and encoders for {name}'.format(name=arg))
             with open(arg) as f:
                 from_elm_file(f.read())
 
         if arg.endswith('.json'):
-            print('Generating type alias, decoders and encoders from {name}'.format(name=arg))
+            message('Generating type alias, decoders and encoders from {name}'.format(name=arg))
             with open(arg) as f:
                 arg = arg.split('/')[-1]
                 name = arg.split('.')[0].capitalize()
                 print_everything(f.read(), name)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before this fix:

```
-- TYPE MISMATCH ------------------------------------------------------ Main.elm

`string` is not a function, but you are giving it an argument!

14│                          Decode.string record.hello)
                                           ^^^^^^^^^^^^
Maybe you forgot some parentheses? Or a comma?
```

After this fix:

```
Success! Compiled 1 modules.
Successfully generated elm.js
```

Test case:

```
from __future__ import print_function
import os
from decoder import *
from type_alias import *

type_alias = { "hello" : "world" }
preamble = """
module Main where
import Json.Encode
import Json.Decode
"""

with open('Main.elm', 'w') as f:
    print(preamble, file=f)
    aliases = create_type_alias(type_alias, type_alias_name='HelloWorld')
    print(aliases[0], file=f)
    print(create_encoder(aliases[0], has_snakecase=True, prefix='encode'), file=f)

os.system('elm-make Main.elm --output elm.js')
```

Generated Main.elm before the fix:

```
$ cat Main.elm

module Main where
import Json.Encode
import Json.Decode


type alias HelloWorld =
    { hello : String
    }

encodeHelloWorld : HelloWorld -> Json.Encode.Value
encodeHelloWorld record =
    Json.Encode.object
        [ ("hello", Json.Decode.string record.hello)
        ]
```
