### PR TITLE
Update reference to depreciated elm-json-extra package

### DIFF
--- a/elm/TypeAlias.elm
+++ b/elm/TypeAlias.elm
@@ -720,7 +720,7 @@ originalImports =
     """
 import Json.Encode
 import Json.Decode exposing ((:=))
--- elm-package install --yes circuithub/elm-json-extra
+-- elm-package install --yes elm-community/json-extra
 import Json.Decode.Extra exposing ((|:))
     """
         |> String.trim


### PR DESCRIPTION
Part of the generated Elm code produces this comment:
```
-- elm-package install --yes circuithub/elm-json-extra
```

`circuithub/elm-json-extra` doesn't work with Elm 0.18 as it's depreciated, with the package now moved to `elm-community/json-extra`. This PR updates the package reference in the generated comment.