### PR TITLE
Change the decoder convention from decodeX to xDecoder

### DIFF
--- a/elm/TypeAlias.elm
+++ b/elm/TypeAlias.elm
@@ -53,6 +53,14 @@ capitalize name =
         x :: xs ->
             (String.toUpper (String.fromChar x)) ++ (String.fromList xs)
 
+unCapitalize : String -> String
+unCapitalize name =
+    case String.toList name of
+        [] ->
+            ""
+
+        x :: xs ->
+            (String.toLower (String.fromChar x)) ++ (String.fromList xs)
 
 badCharsRegex : Regex
 badCharsRegex =

--- a/elm/TypeAlias/O17.elm
+++ b/elm/TypeAlias/O17.elm
@@ -2,7 +2,7 @@ module TypeAlias.O17 exposing (..)
 
 import Regex exposing (regex, replace)
 import Types
-import TypeAlias exposing (TypeAlias, Field, capitalize, getFields, getTypeAliasName, getFieldNameAndType, prefixers, knownDecoders)
+import TypeAlias exposing (TypeAlias, Field, capitalize, unCapitalize, getFields, getTypeAliasName, getFieldNameAndType, prefixers, knownDecoders)
 
 
 formatDecoderField : Field -> String
@@ -72,12 +72,11 @@ createDecoder string =
                 |> String.join "\n        "
     in
         String.join ""
-            [ "decode"
-            , typeName
+            [ unCapitalize (typeName ++ "Decoder")
             , " : Json.Decode.Decoder "
             , typeName
-            , "\ndecode"
-            , typeName
+            , "\n"
+            , unCapitalize (typeName ++ "Decoder")
             , " =\n    Json.Decode.succeed "
             , typeName
             , "\n        "
@@ -103,12 +102,11 @@ createPipelineDecoder string =
                 |> String.join "\n        "
     in
         String.join ""
-            [ "decode"
-            , typeName
+            [ unCapitalize (typeName ++ "Decoder")
             , " : Json.Decode.Decoder "
             , typeName
-            , "\ndecode"
-            , typeName
+            , "\n"
+            , unCapitalize (typeName ++ "Decoder")
             , " =\n    Json.Decode.Pipeline.decode "
             , typeName
             , "\n        "
@@ -169,7 +167,8 @@ runtimeGuessDecoder field =
                     else
                         "$Json$Decode." ++ lower
                 else
-                    "decode" ++ (capitalize typeName)
+                    unCapitalize (typeName ++ "Decoder")
+
     in
         typeNames
             |> List.map guessSingleDecoder
@@ -192,7 +191,7 @@ runtimeGuessEncoder field =
             else
                 "$Json$Encode." ++ lower
         else
-            "decode" ++ (capitalize typeName)
+            unCapitalize (typeName ++ "Decoder")
 
 
 runtimeDecodeField : Field -> String

--- a/elm/TypeAlias/O18.elm
+++ b/elm/TypeAlias/O18.elm
@@ -2,7 +2,7 @@ module TypeAlias.O18 exposing (..)
 
 import Regex exposing (regex, replace)
 import Types
-import TypeAlias exposing (TypeAlias, Field, capitalize, getFields, getTypeAliasName, getFieldNameAndType, prefixers, knownDecoders)
+import TypeAlias exposing (TypeAlias, Field, capitalize, unCapitalize, getFields, getTypeAliasName, getFieldNameAndType, prefixers, knownDecoders)
 
 
 formatDecoderField : Field -> String
@@ -84,12 +84,11 @@ createDecoder string =
             "import Json.Decode.Pipeline\n\n" ++ (createPipelineDecoder string)
         else
             String.join ""
-                [ "decode"
-                , typeName
+                [ unCapitalize (typeName ++ "Decoder")
                 , " : Json.Decode.Decoder "
                 , typeName
-                , "\ndecode"
-                , typeName
+                , "\n"
+                , unCapitalize (typeName ++ "Decoder")
                 , " =\n    Json.Decode."
                 , mapName
                 , " "
@@ -117,12 +116,11 @@ createPipelineDecoder string =
                 |> String.join "\n        "
     in
         String.join ""
-            [ "decode"
-            , typeName
+            [ unCapitalize (typeName ++ "Decoder")
             , " : Json.Decode.Decoder "
             , typeName
-            , "\ndecode"
-            , typeName
+            , "\n"
+            , unCapitalize (typeName ++ "Decoder")
             , " =\n    Json.Decode.Pipeline.decode "
             , typeName
             , "\n        "
@@ -183,7 +181,7 @@ runtimeGuessDecoder field =
                     else
                         "$Json$Decode." ++ lower
                 else
-                    "decode" ++ (capitalize typeName)
+                    unCapitalize (typeName ++ "Decoder")
     in
         typeNames
             |> List.map guessSingleDecoder
@@ -206,7 +204,7 @@ runtimeGuessEncoder field =
             else
                 "$Json$Encode." ++ lower
         else
-            "decode" ++ (capitalize typeName)
+            unCapitalize (typeName ++ "Decoder")
 
 
 runtimeDecodeField : Field -> String


### PR DESCRIPTION
The reason for this proposal is that a `Decoder x` is not a decode
function by itself. Instead, the true decode function looks something
like:

```elm
decodeX = decodeString xDecoder
```

The generated decoders also differ from the generated encode functions (which *do* encode values directly).

This change makes that distinction more clear, which I believe ought to aid with comprehension.