### PR TITLE
Generated Code is using non existing alias

### DIFF
--- a/elm/UnionType.elm
+++ b/elm/UnionType.elm
@@ -118,7 +118,7 @@ createEncoder union =
             , union.name
             , " : "
             , union.name
-            , " -> Json.Value"
+            , " -> Json.Encode.Value"
             , "\nencode"
             , union.name
             , " =\n toString >> Json.Encode.string"


### PR DESCRIPTION
The generated code is using `Json.Value` but setting the alias is not part of the generated code.

It is `Json.Encode.Value` by default. Otherwise there has to be `import Json.Encode as Json`  to achieve this behavior. I did the change to have the first solution.